### PR TITLE
Termostat (input)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Each node uses special (hidden) gateway node to communicate with Hapcan system. 
 - **RTC output** allows set time and date for [ethernet module](http://hapcan.com/devices/universal/univ_3/univ_3-102-0-x/index.htm)
 - **State output** helps request Hapcan modules status informations
 - **Temp input** receives temperature messages from [button modules](http://hapcan.com/devices/universal/univ_3/univ_3-4-x-x.htm)
+- **Thermostat input** receives thermostat messages from [button modules](https://hapcan.com/devices/universal/univ_3/univ_3-1-3-x/index.htm)
 
 # Usage
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-red-contrib-hapcan",
   "description": "Set of nodes for HAPCAN (home automation project based on CAN bus).",
-  "version": "1.4.0",
+  "version": "1.3.1",
   "dependencies": {
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-red-contrib-hapcan",
   "description": "Set of nodes for HAPCAN (home automation project based on CAN bus).",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "dependencies": {
   },
   "keywords": [
@@ -17,7 +17,9 @@
     "ir",
     "infrared",
     "receive",
-    "send"
+    "send",
+    "temperature",
+    "thermostat"
   ],
   "homepage": "https://github.com/Onixarts/node-red-contrib-hapcan",
   "bugs": {
@@ -58,6 +60,7 @@
       "rtc": "rtc.js",
       "state": "state.js",
       "temp" : "temp.js",
+      "thermostat" : "thermostat.js",
       "hapcan-gateway": "hapcan-gateway.js"
     }
 }

--- a/temp.js
+++ b/temp.js
@@ -41,6 +41,8 @@
                 return;
 
             hapcanMessage.temp = Number(Number(((hapcanMessage.frame[8] * 256) + hapcanMessage.frame[9]) * 0.0625).toFixed(1));
+            hapcanMessage.setpoint = Number(Number(((hapcanMessage.frame[10] * 256) + hapcanMessage.frame[11]) * 0.0625).toFixed(2));
+            hapcanMessage.hysteresis = Number(Number(hapcanMessage.frame[12] * 0.0625).toFixed(4));
 
             node.send({topic: 'Temperature sensor message', payload: hapcanMessage});
         });

--- a/thermostat.html
+++ b/thermostat.html
@@ -1,47 +1,47 @@
 <script type="text/javascript">
-    RED.nodes.registerType('temp-input',{
+    RED.nodes.registerType('thermostat-input', {
         category: 'hapcan',
         color: '#D3D3D3',
         defaults: {
-            gateway: {type:"hapcan-gateway", required: true},
-            name: {value:""},
-            group: {value: 1, required: true, validate: function(val){return (val > 0 && val < 256);} },
-            node: {value: 1, required: true, validate: function(val){return (val > 0 && val < 256);}},
+            gateway: { type: "hapcan-gateway", required: true },
+            name: { value: "" },
+            group: { value: 1, required: true, validate: function (val) { return (val > 0 && val < 256); } },
+            node: { value: 1, required: true, validate: function (val) { return (val > 0 && val < 256); } },
         },
-        inputs:0,
-        outputs:1,
+        inputs: 0,
+        outputs: 1,
         icon: "relay-output.png",
         align: 'left',
-        label: function() {
-            return (this.name||"temp input") + ' ('+this.node+','+this.group+')';
+        label: function () {
+            return (this.name || "th/stat input") + ' (' + this.node + ',' + this.group + ')';
         },
-        labelStyle: function() { return this.name?"node_label_italic":""; } ,
-        oneditprepare: function() {
+        labelStyle: function () { return this.name ? "node_label_italic" : ""; },
+        oneditprepare: function () {
 
             var nodeOptions = '';
             var groupOptions = '';
-            for(var i = 1; i < 256; i++)
-            {
+            for (var i = 1; i < 256; i++) {
                 var selectedNode = '';
-                if((Number(this.node) === i))
+                if ((Number(this.node) === i)) {
                     selectedNode = 'selected="selected"';
-                nodeOptions += '<option '+ selectedNode +' value="'+i+'">'+i+'</option>';
+                }
+                nodeOptions += '<option ' + selectedNode + ' value="' + i + '">' + i + '</option>';
 
                 var selectedGroup = '';
-                if((Number(this.group) === i))
+                if ((Number(this.group) === i))
                     selectedGroup = 'selected="selected"';
-                
-                groupOptions += '<option '+ selectedGroup +' value="'+i+'">'+i+'</option>';
+
+                groupOptions += '<option ' + selectedGroup + ' value="' + i + '">' + i + '</option>';
             }
-            
+
             $("#node-input-node").append(nodeOptions);
             $("#node-input-group").append(groupOptions);
         }
-        });
+    });
 
 </script>
 
-<script type="text/x-red" data-template-name="temp-input">
+<script type="text/x-red" data-template-name="thermostat-input">
     <div class="form-row">
         <label for="node-input-name"><i class="icon-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Device name">
@@ -60,14 +60,14 @@
     </div>
 </script>
 
-<script type="text/x-red" data-help-name="temp-input">
-    <p>Receives Hapcan temperature frame from UNIV-3.1.2/3 and UNIV-1.0.4 modules.</p>
-    <p>The node emit temperature messages sent by button modules. It uses the Ethernet gateway to receive messages from Hapcan bus.</p>
+<script type="text/x-red" data-help-name="thermostat-input">
+    <p>Receives Hapcan thermostat frame from UNIV-3.1.2/3 modules.</p>
+    <p>The node emit thermostat messages sent by button modules. It uses the Ethernet gateway to receive messages from Hapcan bus.</p>
     
     <h3>Output</h3>
     <dl class="message-properties">
         <dt>payload <span class="property-type">object</span></dt>
-        <dd>Hapcan message object with temperature data.</dd>
+        <dd>Hapcan message object with thermostat data.</dd>
     </dl>
     
     <h3>Details</h3>
@@ -90,22 +90,18 @@
         <dd>Sender module group number.</dd>
 
         <dt>type <span class="property-type">number</span></dt>
-        <dd>Data type in message (0x11 = temperature)</dd>
+        <dd>Data type in message (0x12 = thermostat)</dd>
 
-        <dt>temp <span class="property-type">number</span></dt>
-        <dd>Temperature in Celsius degrees, rounded to 1 decimal place.</dd>
+        <dt>position <span class="property-type">enum</span></dt>
+        <dd>Current thermostat status: <i>ABOVE</i>, <i>BELOW</i>, <i>POWERUP</i>.</dd>
 
-        <dt>setpoint <span class="property-type">number</span></dt>
-        <dd>Thermostat setpoint in Celsius degrees.</dd>
-
-        <dt>hysteresis <span class="property-type">number</span></dt>
-        <dd>Thermostat hysteresis in Celsius degrees.</dd>
+        <dt>enabled <span class="property-type">bool</span></dt>
+        <dd>Thermostat's state representation as bool value, <i>true</i> or <i>false</i>.</dd>
     </dl>
 
     <h3>References</h3>
     <ul>
         <li><a href="http://hapcan.com/devices/universal/univ_3/univ_3-1-x-x.htm">Hapcan buttons UNIV-3-1-x</a> - module firmware notes.</li>
-        <li><a href="http://hapcan.com/devices/universal/univ_v1-0/univ_v1-0-4-0/index.htm">Hapcan temperature sensor UNIV-1.0.4</a> - module firmware notes.</li>
     </ul>
 
 </script>

--- a/thermostat.js
+++ b/thermostat.js
@@ -1,0 +1,71 @@
+module.exports = function (RED) {
+
+    function ThermostatInputNode(config) {
+        RED.nodes.createNode(this, config);
+        var node = this;
+
+        node.gateway = RED.nodes.getNode(config.gateway);
+        node.group = config.group;
+        node.node = config.node;
+        node.name = config.name;
+
+        node.hapcanId = ("00" + node.node).slice(-3) + ("00" + node.group).slice(-3) + '_';
+
+        this.status({ fill: "grey", shape: "dot", text: "not registered to gateway" });
+
+        if (node.gateway) {
+            node.gateway.register(node);
+        }
+        else {
+            node.error('Invalid configuration. Gateway is required.');
+        }
+
+        this.on('close', function (done) {
+            if (node.gateway) {
+                node.gateway.deregister(node, done);
+            }
+        });
+
+        node.gateway.eventEmitter.on('messageReceived_304', function (data) {
+
+            var hapcanMessage = data.payload;
+
+            if (hapcanMessage.node != node.node || hapcanMessage.group != node.group)
+                return;
+
+            hapcanMessage.type = hapcanMessage.frame[7];
+
+            if (hapcanMessage.type != 0x12)
+                return;
+
+            switch (hapcanMessage.frame[8]) {
+                case 0x00:
+                    hapcanMessage.position = 'BELOW';
+                    break;
+                case 0x80:
+                    hapcanMessage.position = 'POWERUP';
+                    break;
+                case 0xFF:
+                    hapcanMessage.position = 'ABOVE';
+                    break;
+            }
+
+            switch (hapcanMessage.frame[9]) {
+                case 0xFF:
+                    hapcanMessage.enabled = true;
+                    break;
+                case 0x00:
+                    hapcanMessage.enabled = false;
+                    break;
+            }
+
+            node.send({ topic: 'Thermostat message', payload: hapcanMessage });
+        });
+
+        this.on('close', function () {
+            // tidy up any state
+        });
+
+    }
+    RED.nodes.registerType("thermostat-input", ThermostatInputNode);
+}


### PR DESCRIPTION
1. Dodałem nowy moduł: termostat (tylko odczyt, bez kontrolera).
Spróbuję w najbliższym czasie dodać także zapis.
A w dalszym czasie obsługę kontrolera.

2. Do modułu temp-input dodałem odczyt setpoint i histerezy.
Te dwie liczby są związane z termostatem i bardziej pasują do modułu thermostat-input, ale są dostępne w ramce 0x11, czytanej w module temp-input, więc chyba nie ma co komplikować i lepiej je odczytywać razem z temperaturą zamiast pchać do modułu thermostat-input dekodowanie dwóch ramek (0x11 i 0x12).